### PR TITLE
TokenVault: Implementing full EIP-20 support

### DIFF
--- a/contracts/TokenVault.sol
+++ b/contracts/TokenVault.sol
@@ -100,11 +100,6 @@ contract TokenVault is Ownable, Recoverable {
 
     token = _token;
 
-    // Check the address looks like a token contract
-    if(!token.isToken()) {
-      throw;
-    }
-
     // Give argument
     if(_freezeEndsAt == 0) {
       throw;


### PR DESCRIPTION
Previously we had a check for isToken() interface function.
The check was important to test if the address is actually a token, wrong token
would make claiming upon unsuccesful locking impossible.

However, isToken() is not part of the official EIP-20 token specification,
making this particular implementation of the TokenVault TokenMarket specific.

TokenVault should support all EIP-20 tokens, including our SecurityToken.

The check is not needed anymore, since we inherit Recoverable, which enables
us to claim any tokens which are not locked. Hence, removing the check.