### PR TITLE
PayoutContract: Fixing payout distribution, and tests

### DIFF
--- a/contracts/security-token/tests/PayoutContract.sol
+++ b/contracts/security-token/tests/PayoutContract.sol
@@ -7,7 +7,6 @@ contract PayoutContract is InvestorInteractionContract {
   ERC20 payoutToken;
   address from;
   uint256 initialBalance;
-  uint256 oneUnit;
 
   function PayoutContract(CheckpointToken _token, ERC20 _payoutToken, KYCInterface _KYC, bytes32 name, bytes32 URI, uint256 _type, uint256 _hash, bytes32[] _options) InvestorInteractionContract(_token, _KYC, name, URI, _type, _hash, 0, _options) {
     payoutToken = _payoutToken;
@@ -21,11 +20,10 @@ contract PayoutContract is InvestorInteractionContract {
     payoutToken.transferFrom(from, address(this), allowed);
 
     initialBalance = payoutToken.balanceOf(address(this));
-    oneUnit = initialBalance / maximumSupply;
   }
 
   function transferTrigger(address from, address to, uint256 amount) internal {
-    payoutToken.transfer(from, amount * oneUnit);
+    payoutToken.transfer(from, (amount * initialBalance) / maximumSupply);
     super.transferTrigger(from, to, amount);
   }
 

--- a/ico/tests/contracts/test_security_token.py
+++ b/ico/tests/contracts/test_security_token.py
@@ -121,7 +121,7 @@ def security_token_url() -> str:
     return "http://tokenmarket.net/"
 
 @pytest.fixture
-def security_token_initial_supply() -> str:
+def security_token_initial_supply() -> int:
     return 999999999000000000000000000
 
 
@@ -189,18 +189,18 @@ def payout_contract(chain, team_multisig, mock_kyc, security_token, test_token, 
 
 @pytest.fixture
 def test_token(chain, team_multisig, token_name, token_symbol, security_token_initial_supply, release_agent, customer) -> Contract:
-    """Create a Crowdsale token where transfer restrictions have been lifted."""
+    """Create a Crowdsale token where transfer restrictions have been lifted. Double the security_token_initial_supply"""
+    """Tokens must be minted in the respective testing functions to test different scenarios"""
 
-    args = [token_name, token_symbol, security_token_initial_supply, 18, True]  # Owner set
+    args = [token_name, token_symbol, 0, 18, True]  # Owner set
 
     tx = {
         "from": team_multisig
     }
 
     token, hash = chain.provider.deploy_contract('CrowdsaleToken', deploy_args=args, deploy_transaction=tx)
-
     token.transact({"from": team_multisig}).setReleaseAgent(team_multisig)
-    token.transact({"from": team_multisig}).releaseTokenTransfer()
+    token.transact({"from": team_multisig}).setMintAgent(team_multisig, True)
 
     return token
 
@@ -452,20 +452,33 @@ def test_voting_contract(chain, voting_contract, security_token, team_multisig, 
     check_gas(chain, voting_contract.transact({"from": team_multisig}).transferInvestorTokens(customer, 123))
     check_gas(chain, voting_contract.transact({"from": customer}).importInvestor(customer))
     check_gas(chain, voting_contract.transact({"from": customer}).act(123))
-    return
 
 
-def test_payout_contract(chain, payout_contract, security_token, test_token, team_multisig, customer):
+def test_payout_contract(chain, payout_contract, security_token, security_token_initial_supply, test_token, team_multisig, customer):
+    test_token.transact({"from": team_multisig}).mint(team_multisig, security_token_initial_supply * 2)
+    test_token.transact({"from": team_multisig}).releaseTokenTransfer()
+
     start_balance = test_token.call().balanceOf(team_multisig)
     assert start_balance > 0
     check_gas(chain, test_token.transact({"from": team_multisig}).approve(payout_contract.address, start_balance))
     check_gas(chain, payout_contract.transact({"from": customer}).fetchTokens())
 
-    initial_balance = test_token.call().balanceOf(team_multisig)
-    check_gas(chain, payout_contract.transact({"from": team_multisig}).act(123))
-    assert test_token.call().balanceOf(team_multisig) > initial_balance
+    check_gas(chain, payout_contract.transact({"from": team_multisig}).act(security_token.call().balanceOf(team_multisig)))
+    assert test_token.call().balanceOf(team_multisig) == start_balance
 
-    return
+
+def test_payout_contract_with_transfer(chain, payout_contract, security_token, security_token_initial_supply, test_token, team_multisig, customer):
+    test_token.transact({"from": team_multisig}).mint(team_multisig, int(security_token_initial_supply / 2))
+    test_token.transact({"from": team_multisig}).releaseTokenTransfer()
+
+    start_balance = test_token.call().balanceOf(team_multisig)
+    assert start_balance > 0
+    check_gas(chain, test_token.transact({"from": team_multisig}).approve(payout_contract.address, start_balance))
+    check_gas(chain, payout_contract.transact({"from": customer}).fetchTokens())
+
+    check_gas(chain, payout_contract.transact({"from": team_multisig}).transfer(customer, security_token.call().balanceOf(team_multisig)))
+    check_gas(chain, payout_contract.transact({"from": customer}).act(security_token.call().balanceOf(team_multisig)))
+    assert test_token.call().balanceOf(customer) == start_balance
 
 
 def test_erc865(chain, security_token, team_multisig, customer, private_key, signer_address):


### PR DESCRIPTION
Problem involving payouts is now fixed, using @voith's math.
Now payout tokens can be more or less numerous than the available security
tokens.

Also, tests are improved to check that payouts are being paid correctly.
Both scenarios (where payout tokens are more or less numerous) are tested.