### PR TITLE
SecurityToken: Changing checkpoint creation to be manual

### DIFF
--- a/contracts/security-token/ERC20SnapshotMixin.sol
+++ b/contracts/security-token/ERC20SnapshotMixin.sol
@@ -1,0 +1,32 @@
+/**
+ * This smart contract code is Copyright 2018, 2019 TokenMarket Ltd. For more information see https://tokenmarket.net
+ * Licensed under the Apache License, version 2.0: https://github.com/TokenMarketNet/ico/blob/master/LICENSE.txt
+ * NatSpec is used intentionally to cover also other than public functions.
+ * Solidity 0.4.18 is intentionally used: it's stable, and our framework is
+ * based on that.
+ */
+
+pragma solidity ^0.4.24;
+
+import "./CheckpointToken.sol";
+
+contract ERC20SnapshotMixin is CheckpointToken {
+  /// @dev This event is emitted upon snapshot creation (source: ERC20Snapshot)
+  event Snapshot(uint256 id);
+
+  /**
+   * @dev This is implemented for the past and future compatibility.
+   *
+   * It is likely that the final ERC20Snapshot from Zeppelin will use this
+   * function to lookup balances, since this is also used by eralier
+   * MiniMeToken, pioneering the concept ERC20Snapshot and our CheckpoinToken
+   * is based on.
+   *
+   * @param account Account address whose balance will be queried
+   * @param snapshotId Snapshot ID (in our implementation CheckpointID)
+   * @return Balance of `account` at `snapshotId`
+   */
+  function balanceOfAt(address account, uint256 snapshotId) external view returns (uint256) {
+    return balanceAt(account, snapshotId);
+  }
+}

--- a/contracts/security-token/tests/InvestorInteractionContract.sol
+++ b/contracts/security-token/tests/InvestorInteractionContract.sol
@@ -8,7 +8,7 @@ import "../ERC865.sol";
 import "zeppelin/contracts/token/ERC20/StandardToken.sol";
 
 contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC865, KYCAttributes {
-  uint256 public blockNumber;
+  uint256 public checkpointID;
   CheckpointToken public token;
   mapping(address => bool) public balanceImported;
 
@@ -20,15 +20,18 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
   uint256 public maximumSupply;
 
   event OptionAdded(address option, bytes32 description);
-  event IICCreated(address token, address KYC, uint256 blockNumber, uint256 maximumSupply);
+  event IICCreated(address token, address KYC, uint256 checkpointID, uint256 maximumSupply);
 
-  function InvestorInteractionContract(CheckpointToken _token, KYCInterface _KYC, bytes32 name, bytes32 URI, uint256 _type, uint256 _hash, uint256 _blockNumber, bytes32[] _options) CheckpointToken("", "", 18) BogusAnnouncement(name, URI, _type, _hash) public {
+  function InvestorInteractionContract(CheckpointToken _token, KYCInterface _KYC, bytes32 name, bytes32 URI, uint256 _type, uint256 _hash, uint256 _checkpointID, bytes32[] _options) CheckpointToken("", "", 18) BogusAnnouncement(name, URI, _type, _hash) public {
     token = _token;
-    if (_blockNumber > 0) {
-      blockNumber = _blockNumber;
+
+    if (_checkpointID > 0) {
+      checkpointID = _checkpointID;
     } else {
-      blockNumber = block.number;
+      checkpointID = _token.currentCheckpointID();
     }
+
+
     KYC = _KYC;
 
     for(uint i=0; i<_options.length; i++) {
@@ -38,9 +41,9 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
       OptionAdded(optionAddress, _options[i]);
     }
 
-    maximumSupply = token.totalSupplyAt(blockNumber);
+    maximumSupply = token.totalSupplyAt(checkpointID);
 
-    IICCreated(_token, _KYC, _blockNumber, maximumSupply);
+    IICCreated(_token, _KYC, _checkpointID, maximumSupply);
   }
 
   function importInvestor(address investor) public {
@@ -48,7 +51,7 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
 
     require(balanceImported[investor] == false);
 
-    uint256 value = token.balanceAt(investor, blockNumber);
+    uint256 value = token.balanceAt(investor, checkpointID);
     uint256 blackHoleBalance = balanceOf(address(0));
     uint256 totalSupplyNow = totalSupply();
 

--- a/contracts/security-token/tests/TestCheckpointFailsafe.sol
+++ b/contracts/security-token/tests/TestCheckpointFailsafe.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.4.18;
 import "../CheckpointToken.sol";
 
 contract TestCheckpointFailsafe {
-  function getTokenBalance(CheckpointToken token, uint blockNumber, address who, uint index) public constant returns (bool result, uint balance, uint latestBlock) {
-    uint tmpBlock;
+  function getTokenBalance(CheckpointToken token, uint checkpointID, address who, uint index) public constant returns (bool result, uint balance, uint latestCheckpointID) {
+    uint tmpCheckpointID;
     uint tmpBalance;
 
-    (latestBlock, balance) = token.tokenBalances(who, index);
-    (tmpBlock, tmpBalance) = token.tokenBalances(who, index+1);
+    (latestCheckpointID, balance) = token.tokenBalances(who, index);
+    (tmpCheckpointID, tmpBalance) = token.tokenBalances(who, index+1);
 
-    if (latestBlock >= blockNumber && blockNumber < tmpBlock) {
+    if (latestCheckpointID >= checkpointID && checkpointID < tmpCheckpointID) {
       result = true;
     } else {
       result = false;


### PR DESCRIPTION
Making checkpoints a manual matter instead of automatically using block
numbers. This saves gas, since it's cheaper to write to the existing
checkpoint than a new memory location on every transfer().

So, SecurityToken.checkpoint() should be called upon deployment of IICs
instead of block numbers in the future.

Also added ERC20SnapshotMixin to provide support for Zeppelin's (currently
a draft) contract ERC20Snapshot which provides similar functionality.

Also added proper tests, and extended the coverage of the previous test cases.