### PR TITLE
CheckpointToken: Verify transactions only for transferFrom() and transfer()

### DIFF
--- a/contracts/security-token/AdvancedTransferAgent.sol
+++ b/contracts/security-token/AdvancedTransferAgent.sol
@@ -69,7 +69,7 @@ contract AdvancedTransferAgent is RestrictedTransferAgent, Ownable {
     /* We invoke RestrictedTransferAgent here, because whatever it wants to do
        (like KYC checks if KYC is specified), we want to do too. */
     if (blacklist[from] || blacklist[to]) {
-      return 0;
+      revert("Token transaction not permitted");
     } else {
       if (whitelist[from] || whitelist[to]) {
         return value;

--- a/contracts/security-token/ERC865.sol
+++ b/contracts/security-token/ERC865.sol
@@ -35,6 +35,9 @@ contract ERC865 is CheckpointToken {
     address from = recover(hashedTx, _signature);
     require(from != address(0));
 
+    _value = verifyTransaction(from, _to, _value);
+    _fee = verifyTransaction(from, msg.sender, _fee);
+
     transferInternal(from, _to, _value);
     transferInternal(from, msg.sender, _fee);
 

--- a/contracts/security-token/RestrictedTransferAgent.sol
+++ b/contracts/security-token/RestrictedTransferAgent.sol
@@ -29,7 +29,7 @@ contract RestrictedTransferAgent is SecurityTransferAgent, KYCAttributes {
     } else if (KYC.getAttribute(from, KYCAttribute.CanPushTokens)) {
       return value;
     } else {
-      return 0;
+      revert("Token transaction not permitted");
     }
   }
 }

--- a/contracts/security-token/SecurityToken.sol
+++ b/contracts/security-token/SecurityToken.sol
@@ -32,7 +32,7 @@ contract SecurityToken is CheckpointToken, RBAC, Recoverable, ERC865, ERC20Snaps
   string public constant ROLE_CHECKPOINT = "checkpoint()";
 
   /// @dev Version string telling the token is TM-01, and its version:
-  string public version = 'TM-01 0.2';
+  string public version = 'TM-01 0.3';
 
   /// @dev URL where you can get more information about the security
   ///      (for example company website or investor interface):


### PR DESCRIPTION
Previously transactions were verified in transferInternal() which is not the
right place because it's used for functions like issueTokens(), burnTokens()
and forceTransfer(), which are intentionally with unlimited transfer power, and
hence should not go through a transaction verifier.

From now on, only transactions from transferFrom() and transfer() are verified.
Also, per EIP20 zero value  transactions are now permitted, and
transactionAgent should revert() instead of value=0.

Also version number was bumped to 0.3 because this change fundamentally changes
the operation of issueTokens(), burnTokens() and forceTransfer().